### PR TITLE
r8125: add several fixes and adjustments

### DIFF
--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -20,7 +20,7 @@ define KernelPackage/r8125
   TITLE:=Realtek RTL8125 PCI 2.5 Gigabit Ethernet driver
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8125.ko
-  AUTOLOAD:=$(call AutoProbe,r8125)
+  AUTOLOAD:=$(call AutoProbe,r8125,1)
   PROVIDES:=kmod-r8169
   VARIANT:=regular
   PKG_MAKE_FLAGS += CONFIG_ASPM=n

--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -23,6 +23,7 @@ define KernelPackage/r8125
   AUTOLOAD:=$(call AutoProbe,r8125)
   PROVIDES:=kmod-r8169
   VARIANT:=regular
+  PKG_MAKE_FLAGS += CONFIG_ASPM=n
 endef
 
 define KernelPackage/r8125-rss
@@ -33,7 +34,7 @@ $(call KernelPackage/r8125)
 endef
 
 ifeq ($(BUILD_VARIANT),rss)
-  PKG_MAKE_FLAGS += ENABLE_RSS_SUPPORT=y
+  PKG_MAKE_FLAGS += ENABLE_RSS_SUPPORT=y ENABLE_MULTIPLE_TX_QUEUE=y
 endif
 
 define Build/Compile


### PR DESCRIPTION
Enabling rss support in a driver increases only rx channels to 2, while leaving only 1 tx channel. Option ENABLE_MULTIPLE_TX_QUEUE increases tx channels to 2, so it becomes 2 rx and 2 tx.

CONFIG_ASPM=n disables aspm support for this NIC, fixing strange behavior problems (increased latency, strange uneven throughput and such). With this option disabled the NIC becomes rock solid with stable performance, not worse than r8169 in-tree driver. r8169 disables it by default. 

Other 2 options ENABLE_PAGE_REUSE and ENABLE_RX_PACKET_FRAGMENT should also increase performance by reusing memory pages and processing fragmented packets. Watched this in gentoo distro.

Could you please remove 2nd signed-off-by while cherry-picking, i have only github editor at hand (mobile).